### PR TITLE
fix: use Object.create(null) in resetAll() to prevent prototype pollution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -461,7 +461,7 @@ function createAttemptTracker(options) {
    * Reset all tracking state.
    */
   function resetAll() {
-    challenges = {};
+    challenges = Object.create(null);
   }
 
   /**


### PR DESCRIPTION
Fixes #16

The \esetAll()\ function in \createAttemptTracker()\ was resetting the internal \challenges\ map with \{}\ (plain object), which re-introduces prototype pollution vulnerability that the constructor correctly prevents by using \Object.create(null)\.

This one-line fix ensures \esetAll()\ maintains the same null-prototype protection.