### PR TITLE
fix: replace Math.log2 with ES5-compatible equivalent

### DIFF
--- a/src/behavioral-biometrics.js
+++ b/src/behavioral-biometrics.js
@@ -58,7 +58,7 @@ function entropy(arr) {
   for (var b = 0; b < buckets; b++) {
     if (counts[b] > 0) {
       var p = counts[b] / arr.length;
-      h -= p * Math.log2(p);
+      h -= p * (Math.log(p) / Math.LN2);
     }
   }
   return h;


### PR DESCRIPTION
## Problem

behavioral-biometrics.js uses Math.log2() which is an ES6 (ES2015) API. The entire codebase targets ES5 (var declarations, no arrow functions, prototype-based classes), so this will throw a TypeError in older runtimes (e.g. IE11, older Node.js, embedded V8).

## Fix

Replace Math.log2(p) with the standard ES5 equivalent: Math.log(p) / Math.LN2.

This is mathematically identical and works in all ES5+ environments.