### PR TITLE
fix: bound memory growth in GeoRiskScorer (CWE-770)

### DIFF
--- a/src/geo-risk-scorer.js
+++ b/src/geo-risk-scorer.js
@@ -54,6 +54,11 @@ function createGeoRiskScorer(options) {
   var suspiciousSpeedKmh = options.suspiciousTravelSpeedKmh || SUSPICIOUS_TRAVEL_SPEED_KMH;
   var velocityWindowMs = options.velocityWindowMs || VELOCITY_WINDOW_MS;
   var maxHistory = options.maxHistory || 500;
+  var maxTrackedIPs = options.maxTrackedIPs || 10000;
+  var maxTrackedSessions = options.maxTrackedSessions || 10000;
+  var maxBlockedIPs = options.maxBlockedIPs || 50000;
+  var maxAllowedIPs = options.maxAllowedIPs || 50000;
+  var blocklistTTLMs = options.blocklistTTLMs || 86400000; // 24h default
 
   // Thresholds for action mapping
   var thresholds = options.thresholds || {};
@@ -61,15 +66,19 @@ function createGeoRiskScorer(options) {
   var challengeThreshold = thresholds.challenge || 0.5;
   var warnThreshold = thresholds.warn || 0.3;
 
-  // IP history for velocity checks: { ip: [{ lat, lon, ts, country }] }
-  var _ipHistory = Object.create(null);
-  // Session history for geo-hopping: { sessionId: [{ country, ts }] }
-  var _sessionGeo = Object.create(null);
+  // IP history for velocity checks: Map<ip, {entries, lastAccess}>
+  // Using Map for insertion-order iteration (LRU eviction)
+  var _ipHistory = new Map();
+  // Session history for geo-hopping: Map<sessionId, {entries, lastAccess}>
+  var _sessionGeo = new Map();
   // Regional stats: { country: { attempts, solves } }
   var _regionStats = Object.create(null);
-  // Custom blocklist/allowlist
-  var _blockedIPs = Object.create(null);
-  var _allowedIPs = Object.create(null);
+  // Custom blocklist/allowlist with TTL: Map<ip, timestamp>
+  var _blockedIPs = new Map();
+  var _allowedIPs = new Map();
+  // Counter for throttling cleanup sweeps
+  var _scoresSinceCleanup = 0;
+  var CLEANUP_INTERVAL = 1000; // run cleanup every N scores
 
   var _totalScored = 0;
   var _totalBlocked = 0;
@@ -85,6 +94,39 @@ function createGeoRiskScorer(options) {
       // Splice from front in one call instead of repeated shift() — O(n) once vs O(k*n)
       arr.splice(0, arr.length - cap);
     }
+  }
+
+  /** Evict oldest entries from a Map when it exceeds maxSize. */
+  function _evictLRU(map, maxSize) {
+    if (map.size <= maxSize) return;
+    var toDelete = map.size - maxSize;
+    var iter = map.keys();
+    for (var i = 0; i < toDelete; i++) {
+      map.delete(iter.next().value);
+    }
+  }
+
+  /** Remove expired entries (value < now) from a timestamp Map. */
+  function _expireTTL(map, now) {
+    var keysToDelete = [];
+    map.forEach(function(ts, key) {
+      if (ts < now) keysToDelete.push(key);
+    });
+    for (var i = 0; i < keysToDelete.length; i++) {
+      map.delete(keysToDelete[i]);
+    }
+  }
+
+  /** Periodic cleanup — called every CLEANUP_INTERVAL scores. */
+  function _maybeCleanup() {
+    _scoresSinceCleanup++;
+    if (_scoresSinceCleanup < CLEANUP_INTERVAL) return;
+    _scoresSinceCleanup = 0;
+    var now = Date.now();
+    _expireTTL(_blockedIPs, now);
+    _expireTTL(_allowedIPs, now);
+    _evictLRU(_ipHistory, maxTrackedIPs);
+    _evictLRU(_sessionGeo, maxTrackedSessions);
   }
 
   function _toAction(score) {
@@ -124,7 +166,8 @@ function createGeoRiskScorer(options) {
 
   function _velocityFactor(ip, lat, lon, ts) {
     if (lat == null || lon == null || !ip) return null;
-    var history = _ipHistory[ip];
+    var entry = _ipHistory.get(ip);
+    var history = entry ? entry.entries : null;
     if (!history || history.length === 0) return null;
     var dominated = false;
     var worst = { name: "velocity_ok", score: 0, detail: "Normal travel speed" };
@@ -148,7 +191,8 @@ function createGeoRiskScorer(options) {
 
   function _geoHoppingFactor(sessionId, country, ts) {
     if (!sessionId || !country) return null;
-    var hist = _sessionGeo[sessionId];
+    var entry = _sessionGeo.get(sessionId);
+    var hist = entry ? entry.entries : null;
     if (!hist || hist.length === 0) return null;
     var countries = Object.create(null);
     countries[country.toUpperCase()] = true;
@@ -184,11 +228,17 @@ function createGeoRiskScorer(options) {
     var factors = [];
 
     // Allowlist/blocklist short-circuits
-    if (meta.ip && _allowedIPs[meta.ip]) {
+    var now = Date.now();
+    if (meta.ip && _allowedIPs.has(meta.ip) && _allowedIPs.get(meta.ip) > now) {
       return { score: 0, level: "low", factors: [{ name: "ip_allowlisted", score: 0, detail: meta.ip }], action: "allow" };
     }
-    if (meta.ip && _blockedIPs[meta.ip]) {
+    if (meta.ip && _blockedIPs.has(meta.ip) && _blockedIPs.get(meta.ip) > now) {
       return { score: 1, level: "critical", factors: [{ name: "ip_blocklisted", score: 1, detail: meta.ip }], action: "block" };
+    }
+    // Clean up expired entries checked above
+    if (meta.ip) {
+      if (_allowedIPs.has(meta.ip) && _allowedIPs.get(meta.ip) <= now) _allowedIPs.delete(meta.ip);
+      if (_blockedIPs.has(meta.ip) && _blockedIPs.get(meta.ip) <= now) _blockedIPs.delete(meta.ip);
     }
 
     // Evaluate all factors
@@ -221,17 +271,34 @@ function createGeoRiskScorer(options) {
 
     // Update history
     if (meta.ip && meta.lat != null && meta.lon != null) {
-      if (!_ipHistory[meta.ip]) _ipHistory[meta.ip] = [];
-      _pushCapped(_ipHistory[meta.ip], { lat: meta.lat, lon: meta.lon, ts: ts, country: (meta.country || "").toUpperCase() }, maxHistory);
+      var ipEntry = _ipHistory.get(meta.ip);
+      if (!ipEntry) {
+        ipEntry = { entries: [] };
+      } else {
+        // Re-insert to move to end (most recently used)
+        _ipHistory.delete(meta.ip);
+      }
+      _pushCapped(ipEntry.entries, { lat: meta.lat, lon: meta.lon, ts: ts, country: (meta.country || "").toUpperCase() }, maxHistory);
+      _ipHistory.set(meta.ip, ipEntry);
+      _evictLRU(_ipHistory, maxTrackedIPs);
     }
     if (meta.sessionId && meta.country) {
-      if (!_sessionGeo[meta.sessionId]) _sessionGeo[meta.sessionId] = [];
-      _pushCapped(_sessionGeo[meta.sessionId], { country: meta.country.toUpperCase(), ts: ts }, maxHistory);
+      var sessEntry = _sessionGeo.get(meta.sessionId);
+      if (!sessEntry) {
+        sessEntry = { entries: [] };
+      } else {
+        _sessionGeo.delete(meta.sessionId);
+      }
+      _pushCapped(sessEntry.entries, { country: meta.country.toUpperCase(), ts: ts }, maxHistory);
+      _sessionGeo.set(meta.sessionId, sessEntry);
+      _evictLRU(_sessionGeo, maxTrackedSessions);
     }
 
     _totalScored++;
     if (action === "block") _totalBlocked++;
     if (action === "challenge") _totalChallenged++;
+
+    _maybeCleanup();
 
     return { score: Math.round(composite * 1000) / 1000, level: level, factors: factors, action: action };
   }
@@ -275,12 +342,28 @@ function createGeoRiskScorer(options) {
 
   // ── IP Management ────────────────────────────────────────────────
 
-  function blockIP(ip) { _blockedIPs[ip] = true; }
-  function allowIP(ip) { _allowedIPs[ip] = true; }
-  function unblockIP(ip) { delete _blockedIPs[ip]; }
-  function unallowIP(ip) { delete _allowedIPs[ip]; }
-  function isBlocked(ip) { return !!_blockedIPs[ip]; }
-  function isAllowed(ip) { return !!_allowedIPs[ip]; }
+  function blockIP(ip, ttlMs) {
+    var expiry = Date.now() + (ttlMs || blocklistTTLMs);
+    _blockedIPs.set(ip, expiry);
+    _evictLRU(_blockedIPs, maxBlockedIPs);
+  }
+  function allowIP(ip, ttlMs) {
+    var expiry = Date.now() + (ttlMs || blocklistTTLMs);
+    _allowedIPs.set(ip, expiry);
+    _evictLRU(_allowedIPs, maxAllowedIPs);
+  }
+  function unblockIP(ip) { _blockedIPs.delete(ip); }
+  function unallowIP(ip) { _allowedIPs.delete(ip); }
+  function isBlocked(ip) {
+    if (!_blockedIPs.has(ip)) return false;
+    if (_blockedIPs.get(ip) < Date.now()) { _blockedIPs.delete(ip); return false; }
+    return true;
+  }
+  function isAllowed(ip) {
+    if (!_allowedIPs.has(ip)) return false;
+    if (_allowedIPs.get(ip) < Date.now()) { _allowedIPs.delete(ip); return false; }
+    return true;
+  }
 
   // ── Batch Scoring ────────────────────────────────────────────────
 
@@ -301,25 +384,35 @@ function createGeoRiskScorer(options) {
       totalChallenged: _totalChallenged,
       blockRate: _totalScored > 0 ? Math.round((_totalBlocked / _totalScored) * 1000) / 1000 : 0,
       challengeRate: _totalScored > 0 ? Math.round((_totalChallenged / _totalScored) * 1000) / 1000 : 0,
-      trackedIPs: Object.keys(_ipHistory).length,
-      trackedSessions: Object.keys(_sessionGeo).length,
+      trackedIPs: _ipHistory.size,
+      trackedSessions: _sessionGeo.size,
       regionCount: Object.keys(_regionStats).length,
-      blockedIPs: Object.keys(_blockedIPs).length,
-      allowedIPs: Object.keys(_allowedIPs).length
+      blockedIPs: _blockedIPs.size,
+      allowedIPs: _allowedIPs.size
     };
   }
 
   // ── Reset ────────────────────────────────────────────────────────
 
   function reset() {
-    _ipHistory = Object.create(null);
-    _sessionGeo = Object.create(null);
+    _ipHistory = new Map();
+    _sessionGeo = new Map();
     _regionStats = Object.create(null);
-    _blockedIPs = Object.create(null);
-    _allowedIPs = Object.create(null);
+    _blockedIPs = new Map();
+    _allowedIPs = new Map();
     _totalScored = 0;
     _totalBlocked = 0;
     _totalChallenged = 0;
+    _scoresSinceCleanup = 0;
+  }
+
+  /** Force a cleanup sweep — evict LRU entries and expire TTLs. */
+  function cleanup() {
+    var now = Date.now();
+    _expireTTL(_blockedIPs, now);
+    _expireTTL(_allowedIPs, now);
+    _evictLRU(_ipHistory, maxTrackedIPs);
+    _evictLRU(_sessionGeo, maxTrackedSessions);
   }
 
   return {
@@ -334,7 +427,8 @@ function createGeoRiskScorer(options) {
     isBlocked: isBlocked,
     isAllowed: isAllowed,
     summary: summary,
-    reset: reset
+    reset: reset,
+    cleanup: cleanup
   };
 }
 

--- a/tests/geo-risk-scorer-bounds.test.js
+++ b/tests/geo-risk-scorer-bounds.test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+var assert = require("assert");
+var mod = require("../src/geo-risk-scorer");
+var createGeoRiskScorer = mod.createGeoRiskScorer;
+
+describe("GeoRiskScorer — bounded memory (issue #25)", function () {
+  it("should evict oldest IPs when maxTrackedIPs is exceeded", function () {
+    var s = createGeoRiskScorer({ maxTrackedIPs: 5 });
+    for (var i = 1; i <= 10; i++) {
+      s.score({ ip: "10.0.0." + i, country: "US", lat: 37 + i * 0.01, lon: -122 });
+    }
+    var sum = s.summary();
+    assert(sum.trackedIPs <= 5, "trackedIPs should be capped at 5, got " + sum.trackedIPs);
+  });
+
+  it("should evict oldest sessions when maxTrackedSessions is exceeded", function () {
+    var s = createGeoRiskScorer({ maxTrackedSessions: 3 });
+    for (var i = 1; i <= 8; i++) {
+      s.score({ ip: "1.1.1.1", country: "US", sessionId: "sess-" + i });
+    }
+    var sum = s.summary();
+    assert(sum.trackedSessions <= 3, "trackedSessions should be capped at 3, got " + sum.trackedSessions);
+  });
+
+  it("should expire blocked IPs after TTL", function () {
+    var s = createGeoRiskScorer({ blocklistTTLMs: 1 }); // 1ms TTL
+    s.blockIP("9.9.9.9");
+    // Wait a tiny bit for expiry
+    var start = Date.now();
+    while (Date.now() - start < 5) { /* spin */ }
+    assert(!s.isBlocked("9.9.9.9"), "blocked IP should have expired");
+  });
+
+  it("should expire allowed IPs after TTL", function () {
+    var s = createGeoRiskScorer({ blocklistTTLMs: 1 });
+    s.allowIP("8.8.8.8");
+    var start = Date.now();
+    while (Date.now() - start < 5) { /* spin */ }
+    assert(!s.isAllowed("8.8.8.8"), "allowed IP should have expired");
+  });
+
+  it("should not short-circuit on expired blocklist entry", function () {
+    var s = createGeoRiskScorer({ blocklistTTLMs: 1 });
+    s.blockIP("6.6.6.6");
+    var start = Date.now();
+    while (Date.now() - start < 5) { /* spin */ }
+    var r = s.score({ ip: "6.6.6.6", country: "US" });
+    assert(r.score < 1, "expired blocklist should not trigger block");
+    assert.strictEqual(r.action, "allow");
+  });
+
+  it("should cap blocked IPs at maxBlockedIPs", function () {
+    var s = createGeoRiskScorer({ maxBlockedIPs: 5, blocklistTTLMs: 60000 });
+    for (var i = 0; i < 10; i++) {
+      s.blockIP("10.10.10." + i);
+    }
+    var sum = s.summary();
+    assert(sum.blockedIPs <= 5, "blockedIPs should be capped at 5, got " + sum.blockedIPs);
+  });
+
+  it("should expose cleanup() method", function () {
+    var s = createGeoRiskScorer({ maxTrackedIPs: 2 });
+    for (var i = 1; i <= 5; i++) {
+      s.score({ ip: "10.0.0." + i, country: "US", lat: 37, lon: -122 });
+    }
+    s.cleanup();
+    assert(s.summary().trackedIPs <= 2);
+  });
+
+  it("should accept custom TTL per blockIP/allowIP call", function () {
+    var s = createGeoRiskScorer({ blocklistTTLMs: 60000 });
+    s.blockIP("5.5.5.5", 1); // 1ms override
+    var start = Date.now();
+    while (Date.now() - start < 5) { /* spin */ }
+    assert(!s.isBlocked("5.5.5.5"), "per-call TTL should override default");
+  });
+
+  it("should keep most recent IPs during eviction", function () {
+    var s = createGeoRiskScorer({ maxTrackedIPs: 3 });
+    var now = Date.now();
+    // Score 5 IPs in order
+    for (var i = 1; i <= 5; i++) {
+      s.score({ ip: "10.0.0." + i, country: "US", lat: 37, lon: -122, timestamp: now + i * 1000 });
+    }
+    // IP .5 should still be tracked (most recent)
+    // Score from .5 again - it should have history
+    var r = s.score({ ip: "10.0.0.5", country: "US", lat: 37.01, lon: -122, timestamp: now + 6000 });
+    // If properly tracked, velocity check should work (no impossible travel for small move)
+    assert(r.score < 1, "should not be fully blocked for small movement");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes unbounded memory growth in GeoRiskScorer's internal maps by adding LRU eviction and TTL-based expiry.

## Changes

### LRU eviction for IP/session tracking
- \_ipHistory\ and \_sessionGeo\ converted from plain objects to \Map\ for insertion-order iteration
- Configurable \maxTrackedIPs\ and \maxTrackedSessions\ (default 10,000 each)
- Oldest entries evicted when limits exceeded

### TTL-based expiry for blocklist/allowlist
- \lockIP()\ / \llowIP()\ now store expiry timestamps (default 24h via \locklistTTLMs\)
- Per-call TTL override: \lockIP('1.2.3.4', 3600000)\ for 1h block
- Expired entries cleaned up on access and during periodic sweeps

### Automatic cleanup
- Periodic sweep every 1,000 scores prunes expired TTL entries and enforces size limits
- Public \cleanup()\ method for manual invocation

## New config options
| Option | Default | Description |
|--------|---------|-------------|
| \maxTrackedIPs\ | 10,000 | Max IPs in velocity history |
| \maxTrackedSessions\ | 10,000 | Max sessions in geo-hop history |
| \maxBlockedIPs\ | 50,000 | Max blocked IP entries |
| \maxAllowedIPs\ | 50,000 | Max allowed IP entries |
| \locklistTTLMs\ | 86,400,000 (24h) | TTL for block/allow entries |

## Tests
All 73 tests pass (64 existing + 9 new covering bounds/TTL/eviction).

Closes #25