### PR TITLE
ci: enforce coverage thresholds in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           path: coverage/
           retention-days: 30
 
+      - name: Enforce coverage thresholds
+        run: npm run coverage:check
+
       - name: Coverage summary
         if: always()
         run: |

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
                     "test":  "node --test tests/*.test.js",
                     "test:coverage":  "c8 --reporter=text --reporter=lcov --reporter=json-summary node --test tests/*.test.js",
                     "coverage":  "c8 --reporter=text --reporter=lcov node --test tests/*.test.js",
-                    "coverage:check":  "c8 check-coverage --lines 70 --functions 70 --branches 70"
+                    "coverage:check":  "c8 check-coverage --lines 80 --functions 70 --branches 90"
                 },
     "keywords":  [
                      "captcha",


### PR DESCRIPTION
The \coverage:check\ npm script existed but was never run in CI — coverage could regress silently.

- Added enforcement step before summary in CI workflow
- Bumped lines 70%→80%, branches 70%→90%
- Functions stays at 70% (actual 75.84%)
- All thresholds pass (lines 89.96%, branches 99.23%)