### PR TITLE
fix: session stats drift — double-counted blocked sessions and leaked totals

### DIFF
--- a/src/session-risk-aggregator.js
+++ b/src/session-risk-aggregator.js
@@ -273,7 +273,11 @@ function createSessionRiskAggregator(options) {
     var ids = Object.keys(sessions);
     for (var i = 0; i < ids.length; i++) {
       if (now - sessions[ids[i]].lastSeen > sessionTTL) {
+        if (sessions[ids[i]].locked) {
+          stats.blockedSessions = Math.max(0, stats.blockedSessions - 1);
+        }
         delete sessions[ids[i]];
+        stats.totalSessions = Math.max(0, stats.totalSessions - 1);
       }
     }
   }
@@ -454,8 +458,8 @@ function createSessionRiskAggregator(options) {
 
     if (timeline.length > 0) verdict.timeline = timeline;
 
-    // Lock session if blocked
-    if (action === "block") {
+    // Lock session if blocked (avoid double-counting)
+    if (action === "block" && !session.locked) {
       session.locked = true;
       stats.blockedSessions++;
     }
@@ -571,7 +575,11 @@ function createSessionRiskAggregator(options) {
    */
   function removeSession(sessionId) {
     if (!sessions[sessionId]) return { ok: false, error: "session not found" };
+    if (sessions[sessionId].locked) {
+      stats.blockedSessions = Math.max(0, stats.blockedSessions - 1);
+    }
     delete sessions[sessionId];
+    stats.totalSessions = Math.max(0, stats.totalSessions - 1);
     return { ok: true };
   }
 


### PR DESCRIPTION
Three related bugs in SessionRiskAggregator:

1. **stats.blockedSessions double-counted** on re-evaluation: \valuate()\ ran \stats.blockedSessions++\ every time \ction==block\, even for already-locked sessions. Fix: only increment when transitioning \!locked -> locked\.

2. **removeSession() leaked stats**: never decremented \stats.totalSessions\ or \stats.blockedSessions\, causing permanent inflation.

3. **_pruneOld() leaked stats**: deleted expired sessions without updating counters, same drift as (2).

Impact: any long-running aggregator instance would see monotonically growing counters that never reflect removals or TTL expiry.

Also closes #27 (verified all 5 mean helpers already have empty-array guards).