### PR TITLE
fix: replace plain-object maps with Object.create(null) to prevent prototype pollution

### DIFF
--- a/src/ab-experiment-runner.js
+++ b/src/ab-experiment-runner.js
@@ -181,7 +181,7 @@ function createABExperimentRunner(options) {
   var earlyStoppingEnabled = options.earlyStoppingEnabled !== false;
   var earlyStoppingConfidence = typeof options.earlyStoppingConfidence === 'number' ? options.earlyStoppingConfidence : 0.01;
 
-  var experiments = {};
+  var experiments = Object.create(null);
   var experimentOrder = new LruTracker();
   var onResultCallbacks = [];
 
@@ -336,7 +336,7 @@ function createABExperimentRunner(options) {
       allVariants.push({ name: spec.variants[j].name, config: spec.variants[j].config || {} });
     }
 
-    var variantData = {};
+    var variantData = Object.create(null);
     for (var k = 0; k < allVariants.length; k++) {
       variantData[allVariants[k].name] = {
         name: allVariants[k].name,
@@ -634,7 +634,7 @@ function createABExperimentRunner(options) {
   function getAssignmentCounts(experimentId) {
     var exp = experiments[experimentId];
     if (!exp) throw new Error('Unknown experiment: ' + experimentId);
-    var counts = {};
+    var counts = Object.create(null);
     for (var i = 0; i < exp.variantNames.length; i++) {
       counts[exp.variantNames[i]] = 0;
     }
@@ -670,7 +670,7 @@ function createABExperimentRunner(options) {
     for (var i = 0; i < order.length; i++) {
       var exp = experiments[order[i]];
       if (!exp) continue;
-      var variantExport = {};
+      var variantExport = Object.create(null);
       for (var j = 0; j < exp.variantNames.length; j++) {
         var name = exp.variantNames[j];
         var vd = exp.variants[name];
@@ -711,7 +711,7 @@ function createABExperimentRunner(options) {
       if (!e.id || experiments[e.id]) continue;
       if (experimentOrder.length >= maxExperiments) break;
 
-      var variantData = {};
+      var variantData = Object.create(null);
       for (var j = 0; j < e.variantNames.length; j++) {
         var name = e.variantNames[j];
         var src = (e.variants && e.variants[name]) || {};

--- a/src/adaptive-difficulty-tuner.js
+++ b/src/adaptive-difficulty-tuner.js
@@ -65,7 +65,7 @@ function now() {
 }
 
 function shallowMerge(defaults, overrides) {
-  var result = {};
+  var result = Object.create(null);
   var key;
   for (key in defaults) {
     if (defaults.hasOwnProperty(key)) {
@@ -76,7 +76,7 @@ function shallowMerge(defaults, overrides) {
 }
 
 function deepCopyDimensions(dims) {
-  var result = {};
+  var result = Object.create(null);
   var key;
   for (key in dims) {
     if (dims.hasOwnProperty(key)) {
@@ -207,7 +207,7 @@ function createAdaptiveDifficultyTuner(options) {
   var history = new AdjustmentHistory(opts.maxHistory);
   var lastAdjustmentTs = 0;
   var evaluationTimer = null;
-  var listeners = {};
+  var listeners = Object.create(null);
   var totalSolves = 0;
   var totalFails = 0;
   var paused = false;
@@ -396,7 +396,7 @@ function createAdaptiveDifficultyTuner(options) {
   }
 
   function getAllDimensions() {
-    var result = {};
+    var result = Object.create(null);
     for (var key in dimensions) {
       if (dimensions.hasOwnProperty(key)) {
         result[key] = getDimension(key);
@@ -624,7 +624,7 @@ function createAdaptiveDifficultyTuner(options) {
 
   function destroy() {
     stopAutoEval();
-    listeners = {};
+    listeners = Object.create(null);
     eventWindow.clear();
   }
 

--- a/src/behavioral-biometrics.js
+++ b/src/behavioral-biometrics.js
@@ -258,7 +258,7 @@ function createBehavioralBiometrics(options) {
     var posScore = Math.min(posSpread / 100, 1.0);
 
     // 3. No two clicks at exact same position (bot signature)
-    var uniquePositions = {};
+    var uniquePositions = Object.create(null);
     var duplicates = 0;
     for (var k = 0; k < positions.length; k++) {
       var key = positions[k].x + "," + positions[k].y;

--- a/src/captcha-fatigue-detector.js
+++ b/src/captcha-fatigue-detector.js
@@ -87,7 +87,7 @@ function createSession(sessionId, timestamp) {
 }
 
 function createCaptchaFatigueDetector(options) {
-  var opts = {};
+  var opts = Object.create(null);
   var key;
   for (key in DEFAULT_OPTIONS) {
     if (DEFAULT_OPTIONS.hasOwnProperty(key)) opts[key] = DEFAULT_OPTIONS[key];
@@ -96,7 +96,7 @@ function createCaptchaFatigueDetector(options) {
     for (key in options) {
       if (options.hasOwnProperty(key)) {
         if (key === "weights" && typeof options[key] === "object") {
-          opts.weights = {};
+          opts.weights = Object.create(null);
           for (var w in DEFAULT_OPTIONS.weights) {
             if (DEFAULT_OPTIONS.weights.hasOwnProperty(w)) {
               opts.weights[w] = (options.weights && options.weights.hasOwnProperty(w))
@@ -110,9 +110,9 @@ function createCaptchaFatigueDetector(options) {
     }
   }
 
-  var sessions = {};
+  var sessions = Object.create(null);
   var sessionCount = 0;
-  var listeners = {};
+  var listeners = Object.create(null);
   var globalStats = {
     totalEvents: 0, totalSessions: 0,
     fatigueDetections: { none: 0, mild: 0, moderate: 0, severe: 0 },

--- a/src/challenge-rotation-scheduler.js
+++ b/src/challenge-rotation-scheduler.js
@@ -77,7 +77,7 @@ function _xorshift32(seed) {
 // ── Main factory ────────────────────────────────────────────────────
 
 function createChallengeRotationScheduler(options) {
-  var opts = {};
+  var opts = Object.create(null);
   var key;
   for (key in DEFAULT_OPTIONS) {
     if (DEFAULT_OPTIONS.hasOwnProperty(key)) {
@@ -114,7 +114,7 @@ function createChallengeRotationScheduler(options) {
   var _totalRotations = 0;
 
   /** @type {Object<string, Array<{solved:boolean, timeMs:number, ts:number}>>} */
-  var _solveHistory = {};
+  var _solveHistory = Object.create(null);
 
   /** @type {Array<{from:string|null, to:string, ts:number, reason:string}>} */
   var _rotationLog = [];
@@ -126,7 +126,7 @@ function createChallengeRotationScheduler(options) {
   var _timerHandle = null;
 
   /** @type {Object<string, Array<function>>} */
-  var _listeners = {};
+  var _listeners = Object.create(null);
 
 
   // ── Challenge type management ───────────────────────────────────
@@ -606,7 +606,7 @@ function createChallengeRotationScheduler(options) {
     for (var k in _solveHistory) {
       if (_solveHistory.hasOwnProperty(k)) delete _solveHistory[k];
     }
-    _listeners = {};
+    _listeners = Object.create(null);
   }
 
   /**

--- a/src/challenge-template-engine.js
+++ b/src/challenge-template-engine.js
@@ -369,15 +369,15 @@ function createChallengeTemplateEngine(options) {
 
   // ── State ───────────────────────────────────────────────────────
 
-  var templates = {};     // name → template definition
+  var templates = Object.create(null);     // name → template definition
   var templateNames = []; // ordered list for random selection
-  var pending = {};       // challengeId → { templateName, params, createdAt }
+  var pending = Object.create(null);       // challengeId → { templateName, params, createdAt }
   var pendingCount = 0;
   var history = [];       // completed challenges (ring buffer)
   var historyIndex = 0;
 
   // Per-template stats
-  var stats = {};  // name → { generated, validated, passed, failed, avgResponseMs }
+  var stats = Object.create(null);  // name → { generated, validated, passed, failed, avgResponseMs }
 
   // ── Init built-ins ──────────────────────────────────────────────
 
@@ -567,12 +567,12 @@ function createChallengeTemplateEngine(options) {
   }
 
   function _extractDisplayData(params) {
-    var data = {};
+    var data = Object.create(null);
     // Include things needed for rendering, exclude the answer
     if (params.distractors) data.distractors = params.distractors;
     if (params.target && typeof params.target === "object") {
       // For color_shape: include target descriptor but not position
-      data.targetDescription = {};
+      data.targetDescription = Object.create(null);
       if (params.target.color) data.targetDescription.color = params.target.color;
       if (params.target.shape) data.targetDescription.shape = params.target.shape;
       if (params.target.object) data.targetDescription.object = params.target.object;
@@ -660,7 +660,7 @@ function createChallengeTemplateEngine(options) {
    */
   function getStats() {
     var totalGenerated = 0, totalPassed = 0, totalFailed = 0;
-    var perTemplate = {};
+    var perTemplate = Object.create(null);
 
     for (var i = 0; i < templateNames.length; i++) {
       var name = templateNames[i];
@@ -702,7 +702,7 @@ function createChallengeTemplateEngine(options) {
    * @returns {Object} { 1: count, 2: count, ... }
    */
   function getDifficultyDistribution() {
-    var dist = {};
+    var dist = Object.create(null);
     for (var i = 0; i < templateNames.length; i++) {
       var d = templates[templateNames[i]].difficulty;
       dist[d] = (dist[d] || 0) + 1;
@@ -729,7 +729,7 @@ function createChallengeTemplateEngine(options) {
    * @returns {Object} { category: count, ... }
    */
   function getCategories() {
-    var cats = {};
+    var cats = Object.create(null);
     for (var i = 0; i < templateNames.length; i++) {
       var cat = templates[templateNames[i]].category;
       cats[cat] = (cats[cat] || 0) + 1;
@@ -903,7 +903,7 @@ function createChallengeTemplateEngine(options) {
         totalResponseMs: 0, avgResponseMs: 0
       };
     }
-    pending = {};
+    pending = Object.create(null);
     pendingCount = 0;
     history = [];
     historyIndex = 0;

--- a/src/compliance-reporter.js
+++ b/src/compliance-reporter.js
@@ -48,13 +48,13 @@ function _countSeverities(findings, SEV) {
  * @returns {Object} Map of category -> { score, total, passed, criticals, warnings }
  */
 function _computeAllCategoryScores(findings, SEV) {
-  var buckets = {};
+  var buckets = Object.create(null);
   for (var i = 0; i < findings.length; i++) {
     var cat = findings[i].category;
     if (!buckets[cat]) buckets[cat] = [];
     buckets[cat].push(findings[i]);
   }
-  var scores = {};
+  var scores = Object.create(null);
   var cats = Object.keys(buckets);
   for (var c = 0; c < cats.length; c++) {
     var catName = cats[c];
@@ -485,12 +485,12 @@ function createComplianceReporter(options) {
     if (!oldReport || !newReport || !oldReport.findings || !newReport.findings) {
       return { error: "invalid_reports", improved: 0, regressed: 0, unchanged: 0, details: [] };
     }
-    var oldMap = {};
+    var oldMap = Object.create(null);
     for (var oi = 0; oi < oldReport.findings.length; oi++) {
       oldMap[oldReport.findings[oi].id] = oldReport.findings[oi].severity;
     }
 
-    var severityRank = {};
+    var severityRank = Object.create(null);
     severityRank[SEVERITY.PASS] = 0;
     severityRank[SEVERITY.INFO] = 1;
     severityRank[SEVERITY.WARNING] = 2;

--- a/src/index.js
+++ b/src/index.js
@@ -444,13 +444,13 @@ function textSimilarity(a, b) {
   var wordsB = String(b).toLowerCase().split(/\s+/).filter(Boolean);
   if (wordsA.length === 0 || wordsB.length === 0) return 0;
 
-  var setA = {};
+  var setA = Object.create(null);
   var uniqueA = 0;
   wordsA.forEach(function (w) { if (!setA[w]) { setA[w] = true; uniqueA++; } });
 
   var intersection = 0;
   var uniqueB = 0;
-  var setB = {};
+  var setB = Object.create(null);
   wordsB.forEach(function (w) {
     if (!setB[w]) {
       setB[w] = true;
@@ -807,7 +807,7 @@ function createSetAnalyzer(challenges) {
     if (_wordSets) return _wordSets;
     _wordSets = _challenges.map(function (c) {
       var words = String(c.humanAnswer || "").toLowerCase().split(/\s+/).filter(Boolean);
-      var set = {};
+      var set = Object.create(null);
       words.forEach(function (w) { set[w] = true; });
       return set;
     });
@@ -845,7 +845,7 @@ function createSetAnalyzer(challenges) {
     var keysB = Object.keys(setB);
     if (keysA.length === 0 || keysB.length === 0) return 0;
     var intersection = 0;
-    var union = {};
+    var union = Object.create(null);
     keysA.forEach(function (w) { union[w] = true; });
     keysB.forEach(function (w) {
       if (setA[w]) intersection++;
@@ -881,7 +881,7 @@ function createSetAnalyzer(challenges) {
    */
   function keywordCoverage() {
     var totalKeywords = 0;
-    var keywordFrequency = {};
+    var keywordFrequency = Object.create(null);
     var challengesWithKeywords = 0;
     var challengesWithoutKeywords = 0;
 
@@ -969,7 +969,7 @@ function createSetAnalyzer(challenges) {
       ? Math.min(100, (kc.uniqueKeywords / (_challenges.length * 2)) * 100) : 0;
 
     // titleUniqueness: uniqueTitles / totalChallenges × 100
-    var titleSet = {};
+    var titleSet = Object.create(null);
     _challenges.forEach(function (c) {
       var t = (c.title || "").toLowerCase();
       titleSet[t] = true;
@@ -1002,7 +1002,7 @@ function createSetAnalyzer(challenges) {
     return _challenges.map(function (c) {
       var words = c.humanAnswer.split(/\s+/).filter(Boolean);
       var wordCount = words.length;
-      var lowerWords = {};
+      var lowerWords = Object.create(null);
       words.forEach(function (w) { lowerWords[w.toLowerCase()] = true; });
       var uniqueWords = Object.keys(lowerWords).length;
       var totalWordLen = words.reduce(function (s, w) { return s + w.length; }, 0);
@@ -1075,7 +1075,7 @@ function createSetAnalyzer(challenges) {
     }
 
     // identical_titles — group by title in single pass
-    var titleGroups = {};
+    var titleGroups = Object.create(null);
     _challenges.forEach(function (c) {
       var t = (c.title || "").toLowerCase();
       if (!titleGroups[t]) titleGroups[t] = [];
@@ -1656,7 +1656,7 @@ function createSecurityScorer(challenges) {
     }
 
     var totalWords = allWords.length;
-    var uniqueSet = {};
+    var uniqueSet = Object.create(null);
     for (var i = 0; i < allWords.length; i++) {
       uniqueSet[allWords[i]] = true;
     }
@@ -1772,7 +1772,7 @@ function createSecurityScorer(challenges) {
       };
     }
 
-    var uniqueSet = {};
+    var uniqueSet = Object.create(null);
     var weakCount = 0;
     var totalLen = 0;
     for (var i = 0; i < allKeywords.length; i++) {
@@ -1934,7 +1934,7 @@ function createSecurityScorer(challenges) {
     }
 
     // first-word diversity — single object tracks both counts and diversity
-    var firstWordCounts = {};
+    var firstWordCounts = Object.create(null);
     for (var i = 0; i < answers.length; i++) {
       var w = getWords(answers[i]);
       if (w.length > 0) {
@@ -1956,7 +1956,7 @@ function createSecurityScorer(challenges) {
 
     // bigram uniqueness
     var totalBigrams = 0;
-    var uniqueBigrams = {};
+    var uniqueBigrams = Object.create(null);
     for (var i = 0; i < answers.length; i++) {
       var words = getWords(answers[i]);
       for (var j = 0; j < words.length - 1; j++) {
@@ -2609,7 +2609,7 @@ function createPoolManager(options) {
     }
 
     var picked = [];
-    var usedIndices = {};
+    var usedIndices = Object.create(null);
     for (var n = 0; n < count; n++) {
       var rand = (secureRandomInt(1000000) / 1000000) * totalWeight;
       var cumulative = 0;
@@ -2863,7 +2863,7 @@ function createResponseAnalyzer(opts) {
         avgWordLength: 0, hasDescriptiveWords: false, specificity: 'empty' };
     }
 
-    var uniqueSet = {};
+    var uniqueSet = Object.create(null);
     words.forEach(function (w) { uniqueSet[w] = true; });
     var unique = Object.keys(uniqueSet).length;
     var ttr = unique / n;
@@ -2907,7 +2907,7 @@ function createResponseAnalyzer(opts) {
     }
 
     var pairs = [];
-    var duplicatedIndices = {};
+    var duplicatedIndices = Object.create(null);
     for (var i = 0; i < responses.length; i++) {
       for (var j = i + 1; j < responses.length; j++) {
         var sim = textSimilarity(responses[i], responses[j]);
@@ -2951,7 +2951,7 @@ function createResponseAnalyzer(opts) {
 
     var analyses = responses.map(analyzeResponse);
     var totalWords = 0, descriptiveCount = 0, emptyCount = 0;
-    var specificities = {};
+    var specificities = Object.create(null);
     analyses.forEach(function (a) {
       totalWords += a.wordCount;
       if (a.hasDescriptiveWords) descriptiveCount++;
@@ -3740,7 +3740,7 @@ function createTokenVerifier(options) {
       if (metaKeys.length > 10) {
         throw new Error('metadata cannot have more than 10 keys');
       }
-      payload.meta = {};
+      payload.meta = Object.create(null);
       for (var i = 0; i < metaKeys.length; i++) {
         var k = metaKeys[i];
         var v = params.metadata[k];
@@ -5028,13 +5028,13 @@ function createRateLimiter(options) {
   var maxClients = _posOpt(options.maxClients, 10000);
 
   // Sets for O(1) lookup
-  var allowSet = {};
-  var blockSet = {};
+  var allowSet = Object.create(null);
+  var blockSet = Object.create(null);
   (options.allowlist || []).forEach(function (id) { allowSet[id] = true; });
   (options.blocklist || []).forEach(function (id) { blockSet[id] = true; });
 
   // clientId -> { timestamps: number[], lastAccess: number }
-  var clients = {};
+  var clients = Object.create(null);
   var clientCount = 0;
 
   // Stats
@@ -5256,7 +5256,7 @@ function createRateLimiter(options) {
    * @returns {Object} Map of clientId -> check result
    */
   function checkBatch(clientIds, opts) {
-    var results = {};
+    var results = Object.create(null);
     for (var i = 0; i < clientIds.length; i++) {
       results[clientIds[i]] = check(clientIds[i], opts);
     }
@@ -5364,7 +5364,7 @@ function createRateLimiter(options) {
    * @returns {Object}
    */
   function exportState() {
-    var clientData = {};
+    var clientData = Object.create(null);
     Object.keys(clients).forEach(function (id) {
       clientData[id] = {
         timestamps: clients[id].timestamps.slice(),
@@ -5387,7 +5387,7 @@ function createRateLimiter(options) {
     if (!state || typeof state !== "object") return;
 
     if (state.clients) {
-      clients = {};
+      clients = Object.create(null);
       clientCount = 0;
       Object.keys(state.clients).forEach(function (id) {
         clients[id] = {
@@ -5399,11 +5399,11 @@ function createRateLimiter(options) {
     }
 
     if (state.allowlist) {
-      allowSet = {};
+      allowSet = Object.create(null);
       state.allowlist.forEach(function (id) { allowSet[id] = true; });
     }
     if (state.blocklist) {
-      blockSet = {};
+      blockSet = Object.create(null);
       state.blocklist.forEach(function (id) { blockSet[id] = true; });
     }
   }
@@ -5439,7 +5439,7 @@ function createRateLimiter(options) {
    * Reset all state.
    */
   function reset() {
-    clients = {};
+    clients = Object.create(null);
     clientCount = 0;
     totalChecks = 0;
     totalAllowed = 0;
@@ -5520,7 +5520,7 @@ function createClientFingerprinter(options) {
     webglVendor: 0.10,
     fonts: 0.10,
   };
-  var signalWeights = {};
+  var signalWeights = Object.create(null);
   var k;
   for (k in defaultWeights) {
     if (defaultWeights.hasOwnProperty(k)) {
@@ -5531,11 +5531,11 @@ function createClientFingerprinter(options) {
   }
 
   // Storage: fingerprint hash -> { signals, firstSeen, lastSeen, visits, ipSet, meta }
-  var store = {};
+  var store = Object.create(null);
   var storeOrder = new LruTracker(); // O(1) LRU tracking
 
   // IP -> [{ fingerprintHash, timestamp }] for change tracking
-  var ipHistory = {};
+  var ipHistory = Object.create(null);
 
   // Known bot fingerprint patterns
   var botPatterns = [
@@ -5679,7 +5679,7 @@ function createClientFingerprinter(options) {
     var now = Date.now();
     var cutoff = now - changeWindowMs;
     var recent = ipHistory[ip].filter(function (e) { return e.timestamp >= cutoff; });
-    var uniqueHashes = {};
+    var uniqueHashes = Object.create(null);
     for (var i = 0; i < recent.length; i++) {
       uniqueHashes[recent[i].fingerprintHash] = true;
     }
@@ -5819,7 +5819,7 @@ function createClientFingerprinter(options) {
    */
   function getStats() {
     var totalVisits = 0;
-    var totalIps = {};
+    var totalIps = Object.create(null);
     for (var hash in store) {
       if (!store.hasOwnProperty(hash)) continue;
       totalVisits += store[hash].visits;
@@ -5857,7 +5857,7 @@ function createClientFingerprinter(options) {
   function importState(state) {
     if (!state || typeof state !== "object") return;
     if (state.store) {
-      store = {};
+      store = Object.create(null);
       for (var h in state.store) {
         if (state.store.hasOwnProperty(h)) {
           store[h] = state.store[h];
@@ -5868,7 +5868,7 @@ function createClientFingerprinter(options) {
       storeOrder.fromArray(state.storeOrder);
     }
     if (state.ipHistory) {
-      ipHistory = {};
+      ipHistory = Object.create(null);
       for (var ip in state.ipHistory) {
         if (state.ipHistory.hasOwnProperty(ip)) {
           ipHistory[ip] = state.ipHistory[ip];
@@ -5881,9 +5881,9 @@ function createClientFingerprinter(options) {
    * Reset all state.
    */
   function reset() {
-    store = {};
+    store = Object.create(null);
     storeOrder.clear();
-    ipHistory = {};
+    ipHistory = Object.create(null);
   }
 
   /**
@@ -5981,9 +5981,9 @@ function createIncidentCorrelator(options) {
   };
 
   // clientId -> incidentId mapping for correlation
-  var clientIncidents = {};
+  var clientIncidents = Object.create(null);
   // incidentId -> incident object
-  var incidents = {};
+  var incidents = Object.create(null);
   var incidentOrder = []; // oldest first for LRU eviction
   var incidentOrderStart = 0; // pointer to first live entry (avoids O(n) shift)
   var nextIncidentId = 1;
@@ -6045,7 +6045,7 @@ function createIncidentCorrelator(options) {
    */
   function getIncidentSummary(incident) {
     // Shallow-copy the flat { type: count } map
-    var typesCopy = {};
+    var typesCopy = Object.create(null);
     for (var t in incident.signalTypes) {
       if (incident.signalTypes.hasOwnProperty(t)) {
         typesCopy[t] = incident.signalTypes[t];
@@ -6259,13 +6259,13 @@ function createIncidentCorrelator(options) {
       var inc = incidents[incidentOrder[i]];
       if (inc && inc.status === "open") activeCount++;
     }
-    var byTypeCopy = {};
+    var byTypeCopy = Object.create(null);
     for (var st in stats.signalsByType) {
       if (stats.signalsByType.hasOwnProperty(st)) {
         byTypeCopy[st] = stats.signalsByType[st];
       }
     }
-    var bySevCopy = {};
+    var bySevCopy = Object.create(null);
     for (var sv in stats.incidentsBySeverity) {
       if (stats.incidentsBySeverity.hasOwnProperty(sv)) {
         bySevCopy[sv] = stats.incidentsBySeverity[sv];
@@ -6286,8 +6286,8 @@ function createIncidentCorrelator(options) {
    * Reset all state.
    */
   function reset() {
-    clientIncidents = {};
-    incidents = {};
+    clientIncidents = Object.create(null);
+    incidents = Object.create(null);
     incidentOrder = [];
     incidentOrderStart = 0;
     nextIncidentId = 1;
@@ -6295,7 +6295,7 @@ function createIncidentCorrelator(options) {
     stats.totalIncidents = 0;
     stats.totalAlerts = 0;
     stats.totalEscalations = 0;
-    stats.signalsByType = {};
+    stats.signalsByType = Object.create(null);
     stats.incidentsBySeverity = { info: 0, warning: 0, high: 0, critical: 0 };
   }
 
@@ -8189,13 +8189,13 @@ function createFraudRingDetector(options) {
   var signalDecayMs = options.signalDecayMs > 0 ? options.signalDecayMs : 3600000;
   var maxRings = options.maxRings > 0 ? options.maxRings : 200;
 
-  var clients = {};
+  var clients = Object.create(null);
   var clientOrder = new LruTracker();
-  var rings = {};
+  var rings = Object.create(null);
   var ringCounter = 0;
   var onRingCallbacks = [];
-  var parent = {};
-  var rank = {};
+  var parent = Object.create(null);
+  var rank = Object.create(null);
 
   function ufFind(x) {
     if (parent[x] === undefined) { parent[x] = x; rank[x] = 0; }
@@ -8289,15 +8289,15 @@ function createFraudRingDetector(options) {
    * @returns {Object.<string, string[]>}
    */
   function _buildGroupMap(prop) {
-    var map = {};
-    var seen = {};
+    var map = Object.create(null);
+    var seen = Object.create(null);
     var ids = Object.keys(clients);
     for (var i = 0; i < ids.length; i++) {
       var cid = ids[i];
       var arr = clients[cid][prop];
       for (var j = 0; j < arr.length; j++) {
         var key = arr[j];
-        if (!map[key]) { map[key] = []; seen[key] = {}; }
+        if (!map[key]) { map[key] = []; seen[key] = Object.create(null); }
         if (!seen[key][cid]) {
           seen[key][cid] = true;
           map[key].push(cid);
@@ -8324,7 +8324,7 @@ function createFraudRingDetector(options) {
     for (var k = 0; k < ips.length; k++) {
       if (ipMap[ips[k]].length >= 2) clusters.push({ ip: ips[k], clients: ipMap[ips[k]] });
     }
-    var subnetMap = {};
+    var subnetMap = Object.create(null);
     for (var s = 0; s < ips.length; s++) {
       var parts = ips[s].split('.');
       if (parts.length === 4) {
@@ -8382,7 +8382,7 @@ function createFraudRingDetector(options) {
     factors.push({ name: 'ringSize', score: sizeScore, detail: clientIds.length + ' clients' });
 
     // Shared fingerprints (up to 25)
-    var fpSets = {};
+    var fpSets = Object.create(null);
     for (var i = 0; i < clientIds.length; i++) {
       var c = clients[clientIds[i]];
       if (c) for (var j = 0; j < c.fingerprints.length; j++) {
@@ -8398,7 +8398,7 @@ function createFraudRingDetector(options) {
     factors.push({ name: 'sharedFingerprint', score: fpScore, detail: maxShared + '/' + clientIds.length + ' share fingerprint' });
 
     // IP proximity (up to 20)
-    var allIps = {};
+    var allIps = Object.create(null);
     for (var m = 0; m < clientIds.length; m++) {
       var cl = clients[clientIds[m]];
       if (cl) for (var n = 0; n < cl.ips.length; n++) { allIps[cl.ips[n]] = (allIps[cl.ips[n]] || 0) + 1; }
@@ -8449,7 +8449,7 @@ function createFraudRingDetector(options) {
   }
 
   function detectRings() {
-    parent = {}; rank = {};
+    parent = Object.create(null); rank = Object.create(null);
 
     var fpGroups = findSharedFingerprints();
     for (var i = 0; i < fpGroups.length; i++) {
@@ -8475,7 +8475,7 @@ function createFraudRingDetector(options) {
       for (var r = 1; r < pat.length; r++) ufUnion(pat[0], pat[r]);
     }
 
-    var components = {};
+    var components = Object.create(null);
     var ids = Object.keys(clients);
     for (var s = 0; s < ids.length; s++) {
       var root = ufFind(ids[s]);
@@ -8581,7 +8581,7 @@ function createFraudRingDetector(options) {
     return lines.join('\n');
   }
 
-  function reset() { clients = {}; clientOrder.clear(); rings = {}; parent = {}; rank = {}; ringCounter = 0; }
+  function reset() { clients = Object.create(null); clientOrder.clear(); rings = Object.create(null); parent = Object.create(null); rank = Object.create(null); ringCounter = 0; }
 
   return {
     recordEvent: recordEvent, detectRings: detectRings, checkClient: checkClient,
@@ -9540,7 +9540,7 @@ function createI18n(options) {
 
   function addLocale(locale, strings) {
     if (typeof locale !== "string" || !strings || typeof strings !== "object") return;
-    if (!catalogs[locale]) catalogs[locale] = {};
+    if (!catalogs[locale]) catalogs[locale] = Object.create(null);
     var keys = Object.keys(strings);
     for (var i = 0; i < keys.length; i++) {
       catalogs[locale][keys[i]] = String(strings[keys[i]]);
@@ -9563,10 +9563,10 @@ function createI18n(options) {
   }
 
   function exportCatalog() {
-    var result = {};
+    var result = Object.create(null);
     var locales = Object.keys(catalogs);
     for (var i = 0; i < locales.length; i++) {
-      result[locales[i]] = {};
+      result[locales[i]] = Object.create(null);
       var keys = Object.keys(catalogs[locales[i]]);
       for (var j = 0; j < keys.length; j++) {
         result[locales[i]][keys[j]] = catalogs[locales[i]][keys[j]];

--- a/src/session-risk-aggregator.js
+++ b/src/session-risk-aggregator.js
@@ -71,7 +71,7 @@ function _deepCopy(obj) {
 }
 
 function _merge(base, override) {
-  var result = {};
+  var result = Object.create(null);
   var k;
   for (k in base) {
     if (base.hasOwnProperty(k)) result[k] = base[k];
@@ -216,7 +216,7 @@ function createSessionRiskAggregator(options) {
   var allRules = CORRELATION_RULES.concat(customRules);
 
   // sessionId -> { signals: { module: [...] }, firstSeen, lastSeen, metadata }
-  var sessions = {};
+  var sessions = Object.create(null);
 
   // Global stats
   var stats = {
@@ -355,7 +355,7 @@ function createSessionRiskAggregator(options) {
     }
 
     var session = sessions[sessionId];
-    var moduleScores = {};
+    var moduleScores = Object.create(null);
     var activeModules = [];
     var activeWeights = [];
     var activeValues = [];
@@ -524,7 +524,7 @@ function createSessionRiskAggregator(options) {
     var session = sessions[sessionId];
     if (!session) return null;
 
-    var moduleSummary = {};
+    var moduleSummary = Object.create(null);
     var mods = Object.keys(session.signals);
     for (var i = 0; i < mods.length; i++) {
       moduleSummary[mods[i]] = {
@@ -749,7 +749,7 @@ function createSessionRiskAggregator(options) {
    * Reset all state.
    */
   function reset() {
-    sessions = {};
+    sessions = Object.create(null);
     stats = {
       totalSignals: 0,
       totalEvaluations: 0,

--- a/src/trust-score-engine.js
+++ b/src/trust-score-engine.js
@@ -159,7 +159,7 @@ function createTrustScoreEngine(options) {
     behaviorEntropy: 1.0
   };
 
-  var weights = {};
+  var weights = Object.create(null);
   var userWeights = options.weights || {};
   var wKeys = Object.keys(defaultWeights);
   for (var wi = 0; wi < wKeys.length; wi++) {
@@ -257,7 +257,7 @@ function createTrustScoreEngine(options) {
     }
 
     manualSignals = manualSignals || {};
-    var signals = {};
+    var signals = Object.create(null);
     var breakdown = [];
 
     // Collect signals from providers
@@ -537,7 +537,7 @@ function createTrustScoreEngine(options) {
    * @returns {Object}
    */
   function getWeights() {
-    var copy = {};
+    var copy = Object.create(null);
     var k = Object.keys(weights);
     for (var i = 0; i < k.length; i++) copy[k[i]] = weights[k[i]];
     return copy;
@@ -619,7 +619,7 @@ function createTrustScoreEngine(options) {
     if (!a || !b) return null;
 
     var signalDiffs = [];
-    var allSignals = {};
+    var allSignals = Object.create(null);
     var sk;
     for (sk in a.signals) allSignals[sk] = true;
     for (sk in b.signals) allSignals[sk] = true;
@@ -650,7 +650,7 @@ function createTrustScoreEngine(options) {
    * @returns {Object}
    */
   function exportState() {
-    var state = {};
+    var state = Object.create(null);
     var order3 = clientOrder.toArray();
     for (var i = 0; i < order3.length; i++) {
       var id = order3[i];


### PR DESCRIPTION
## Summary
Replaces all remaining plain-object map initializations (`= {}`) with `Object.create(null)` across 10 source files, eliminating prototype pollution vectors from dynamic keys (`__proto__`, `constructor`, `toString`, etc.).

This aligns all map usages with the 80 existing `Object.create(null)` patterns already in the codebase.

Fixes #37
