### PR TITLE
perf: replace Array.shift() with splice in remaining hot paths

### DIFF
--- a/src/adaptive-difficulty-tuner.js
+++ b/src/adaptive-difficulty-tuner.js
@@ -110,9 +110,14 @@ EventWindow.prototype.record = function (solved) {
 
 EventWindow.prototype._prune = function () {
   var cutoff = now() - this.windowMs;
-  while (this._events.length > 0 && this._events[0].ts < cutoff) {
-    this._events.shift();
+  // Binary search for the first event that is >= cutoff, then splice
+  var lo = 0, hi = this._events.length;
+  while (lo < hi) {
+    var mid = (lo + hi) >>> 1;
+    if (this._events[mid].ts < cutoff) lo = mid + 1;
+    else hi = mid;
   }
+  if (lo > 0) this._events.splice(0, lo);
 };
 
 EventWindow.prototype.getStats = function () {
@@ -151,8 +156,9 @@ function AdjustmentHistory(maxEntries) {
 
 AdjustmentHistory.prototype.record = function (entry) {
   this._entries.push(entry);
-  while (this._entries.length > this._maxEntries) {
-    this._entries.shift();
+  if (this._entries.length > this._maxEntries) {
+    var excess = this._entries.length - this._maxEntries;
+    this._entries.splice(0, excess);
   }
 };
 

--- a/src/captcha-accessibility-analyzer.js
+++ b/src/captcha-accessibility-analyzer.js
@@ -291,7 +291,7 @@
         severityCounts: sev, summary: summary.join("\n")
       };
       for (var csi = 0; csi < keys.length; csi++) report.criterionScores[keys[csi]] = checks[keys[csi]].score;
-      history.push(report); if (history.length > 100) history.shift();
+      history.push(report); if (history.length > 100) history.splice(0, history.length - 100);
       return report;
     }
 

--- a/src/captcha-stats-collector.js
+++ b/src/captcha-stats-collector.js
@@ -106,8 +106,9 @@ function createStatsCollector(options = {}) {
     };
     windows.push(bucket);
     // Evict old windows
-    while (windows.length > maxWindows) {
-      windows.shift();
+    if (windows.length > maxWindows) {
+      var excess = windows.length - maxWindows;
+      windows.splice(0, excess);
     }
     return bucket;
   }
@@ -157,8 +158,9 @@ function createStatsCollector(options = {}) {
 
     rawRecords.push({ ...entry, timestamp: ts });
     // Cap raw records at 10x maxWindows to bound memory
-    while (rawRecords.length > maxWindows * 100) {
-      rawRecords.shift();
+    if (rawRecords.length > maxWindows * 100) {
+      var excess = rawRecords.length - maxWindows * 100;
+      rawRecords.splice(0, excess);
     }
   }
 

--- a/src/honeypot-injector.js
+++ b/src/honeypot-injector.js
@@ -210,7 +210,7 @@ function createHoneypotInjector(options) {
       if (stats.byStrategy[trap.strategy]) stats.byStrategy[trap.strategy].tripped++;
       if (stats.bySession[trap.sessionId]) stats.bySession[trap.sessionId].tripped++;
       trippedHistory.push({ trapId: trap.id, sessionId: trap.sessionId, value: String(value).substring(0, 200), timestamp: Date.now(), strategy: trap.strategy, fieldName: trap.fieldName });
-      if (trippedHistory.length > maxTrippedHistory) trippedHistory.shift();
+      if (trippedHistory.length > maxTrippedHistory) trippedHistory.splice(0, trippedHistory.length - maxTrippedHistory);
       var confidence = _looksAutomated(value) ? 0.99 : 0.95;
       return { tripped: true, confidence: confidence, trapId: trap.id, strategy: trap.strategy, detail: 'honeypot_triggered', sessionId: trap.sessionId };
     }

--- a/src/solve-pattern-fingerprinter.js
+++ b/src/solve-pattern-fingerprinter.js
@@ -252,7 +252,8 @@ function createSolvePatternFingerprinter(options) {
 
     sess.solves.push(record);
     if (sess.solves.length > maxSamples) {
-      sess.solves.shift();
+      var excess = sess.solves.length - maxSamples;
+      sess.solves.splice(0, excess);
     }
 
     // Regenerate fingerprint if we have enough samples


### PR DESCRIPTION
Addresses remaining instances from #55.

## Changes
- **adaptive-difficulty-tuner.js**: EventWindow._prune() now uses binary search + splice(0, count) instead of shift() loop. AdjustmentHistory.record() uses splice(0, excess) instead of shift() loop.
- **solve-pattern-fingerprinter.js**: Session solve recording uses splice(0, excess) instead of shift().
- **captcha-stats-collector.js**: Window eviction and raw record capping use splice instead of shift loops.
- **captcha-accessibility-analyzer.js**: History cap uses splice instead of shift.
- **honeypot-injector.js**: Tripped history cap uses splice instead of shift.

All changes replace O(n) shift() calls (which re-index the entire array) with O(1) amortized splice operations that remove multiple elements in a single call.

Fixes #55