### PR TITLE
fix: crypto-safe IDs in pool-manager/bot-sig-db + O(1) factor dedup

### DIFF
--- a/src/bot-signature-database.js
+++ b/src/bot-signature-database.js
@@ -1,5 +1,20 @@
 'use strict';
 
+// -- Cryptographic randomness (CWE-330) --
+var _crypto;
+try { _crypto = require("crypto"); } catch (e) { _crypto = null; }
+
+function _secureRandomHex(len) {
+  if (_crypto && typeof _crypto.randomBytes === "function") {
+    return _crypto.randomBytes(Math.ceil(len / 2)).toString("hex").slice(0, len);
+  }
+  var s = "";
+  for (var i = 0; i < len; i++) {
+    s += Math.floor(Math.random() * 16).toString(16);
+  }
+  return s;
+}
+
 /**
  * createBotSignatureDatabase — manages a database of known bot behavioral
  * signatures and matches incoming CAPTCHA solve sessions against them.
@@ -188,7 +203,7 @@ function createBotSignatureDatabase(options) {
   }
 
   function generateId() {
-    return 'sig-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8);
+    return 'sig-' + Date.now().toString(36) + '-' + _secureRandomHex(8);
   }
 
   function clamp01(v) { return v < 0 ? 0 : v > 1 ? 1 : v; }

--- a/src/challenge-pool-manager.js
+++ b/src/challenge-pool-manager.js
@@ -31,6 +31,35 @@
 
 "use strict";
 
+// -- Cryptographic randomness (CWE-330 mitigation) --
+var _crypto;
+try { _crypto = require("crypto"); } catch (e) { _crypto = null; }
+
+/** Crypto-safe random float in [0, 1). */
+function _secureRandom() {
+  if (_crypto && typeof _crypto.randomBytes === "function") {
+    return _crypto.randomBytes(4).readUInt32BE(0) / 4294967296;
+  }
+  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+    var arr = new Uint32Array(1);
+    crypto.getRandomValues(arr);
+    return arr[0] / 4294967296;
+  }
+  return Math.random();
+}
+
+/** Crypto-safe random hex string of given length. */
+function _secureRandomHex(len) {
+  if (_crypto && typeof _crypto.randomBytes === "function") {
+    return _crypto.randomBytes(Math.ceil(len / 2)).toString("hex").slice(0, len);
+  }
+  var s = "";
+  for (var i = 0; i < len; i++) {
+    s += Math.floor(_secureRandom() * 16).toString(16);
+  }
+  return s;
+}
+
 // ── Defaults ────────────────────────────────────────────────────────
 
 var DEFAULT_TARGET_SIZE = 50;       // per tier
@@ -86,7 +115,7 @@ function _createEntry(challenge, tier, now) {
     challenge: challenge,
     tier: tier,
     createdAt: now,
-    id: challenge.id || (Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2))
+    id: challenge.id || _secureRandomHex(16)
   };
 }
 
@@ -197,7 +226,7 @@ function createChallengePoolManager(options) {
    * @returns {Object|null} The challenge object, or null if pool empty
    */
   function take(tier, takeOpts) {
-    var t = tier || tiers[Math.floor(Math.random() * tiers.length)];
+    var t = tier || tiers[Math.floor(_secureRandom() * tiers.length)];
     if (!tierSet[t]) return null;
 
     _purgeExpired(t);

--- a/src/session-risk-aggregator.js
+++ b/src/session-risk-aggregator.js
@@ -359,6 +359,7 @@ function createSessionRiskAggregator(options) {
     var activeModules = [];
     var activeWeights = [];
     var activeValues = [];
+    var factorSet = Object.create(null);
     var allFactors = [];
 
     // Score each module
@@ -372,12 +373,13 @@ function createSessionRiskAggregator(options) {
         activeValues.push(ms);
         activeWeights.push(weights[mod] || 0.1); // default weight for unknown modules
 
-        // Collect unique factors
+        // Collect unique factors (O(1) set lookup instead of O(n) indexOf)
         var sigs = session.signals[mod];
         for (var j = 0; j < sigs.length; j++) {
           var factors = sigs[j].factors || [];
           for (var f = 0; f < factors.length; f++) {
-            if (allFactors.indexOf(factors[f]) === -1) {
+            if (!factorSet[factors[f]]) {
+              factorSet[factors[f]] = true;
               allFactors.push(factors[f]);
             }
           }


### PR DESCRIPTION
**Security (CWE-330):**
- \challenge-pool-manager\: Challenge entry IDs and tier selection now use \crypto.randomBytes\ / \crypto.getRandomValues\ instead of \Math.random()\. Predictable IDs let attackers guess valid challenge tokens.
- \ot-signature-database\: Signature IDs now use crypto-safe hex. Predictable IDs in a security database undermine detection.
- Both gracefully fall back to \Math.random()\ when no crypto API is available.

**Performance:**
- \session-risk-aggregator.evaluate()\: Factor deduplication changed from \Array.indexOf()\ (O(n) per lookup, O(n*k) total across factors) to \Object.create(null)\ set (O(1) per lookup, O(n) total).

37 pool-manager tests pass. 57/59 risk-aggregator tests pass (2 pre-existing failures in \setWeights\ tests — \hasOwnProperty\ on \Object.create(null)\, unrelated to this change).