### PR TITLE
fix: pool pick() can return fewer items due to floating-point precision

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2611,20 +2611,31 @@ function createPoolManager(options) {
     var picked = [];
     var usedIndices = Object.create(null);
     for (var n = 0; n < count; n++) {
+      if (totalWeight <= 0) break; // safety: no remaining weight
       var rand = (secureRandomInt(1000000) / 1000000) * totalWeight;
       var cumulative = 0;
+      var selectedIdx = -1;
       for (var j = 0; j < weights.length; j++) {
         if (usedIndices[j]) continue;
         cumulative += weights[j];
         if (rand <= cumulative) {
-          var id = activeIds[j];
-          registry[id].serves++;
-          picked.push(registry[id].challenge);
-          totalWeight -= weights[j];
-          usedIndices[j] = true;
+          selectedIdx = j;
           break;
         }
       }
+      // Floating-point guard: if cumulative never reached rand due to
+      // precision loss, fall back to the last available index.
+      if (selectedIdx === -1) {
+        for (var k = weights.length - 1; k >= 0; k--) {
+          if (!usedIndices[k]) { selectedIdx = k; break; }
+        }
+      }
+      if (selectedIdx === -1) break; // no candidates left
+      var id = activeIds[selectedIdx];
+      registry[id].serves++;
+      picked.push(registry[id].challenge);
+      totalWeight -= weights[selectedIdx];
+      usedIndices[selectedIdx] = true;
     }
 
     return picked;


### PR DESCRIPTION
## Problem

\createPoolManager().pick(n)\ can silently return fewer than \
\ items when floating-point precision loss causes the cumulative weight sum to not reach the random threshold.

This happens because:
1. We compute \and = (int/1000000) * totalWeight\
2. We then accumulate weights, skipping used indices
3. After subtracting used weights from \	otalWeight\, the remaining cumulative sum may be slightly less than \	otalWeight\ due to IEEE 754 rounding
4. If \and\ falls in the precision gap, no item is selected and the loop moves on

## Fix

- Added a floating-point fallback: when the inner loop finishes without selecting an item, pick the last available (non-used) candidate
- Added a \	otalWeight <= 0\ guard to prevent attempts on exhausted pools
- No behavioral change for the common case — the fallback only fires on edge cases