### PR TITLE
refactor: extract shared option helpers into option-utils module

### DIFF
--- a/src/challenge-pool-manager.js
+++ b/src/challenge-pool-manager.js
@@ -33,8 +33,11 @@
 
 // -- Cryptographic randomness (CWE-330 mitigation) --
 var _cryptoUtils = require("./crypto-utils");
+var _optionUtils = require("./option-utils");
 var _secureRandom = _cryptoUtils.secureRandom;
 var _secureRandomHex = _cryptoUtils.secureRandomHex;
+var _posOpt = _optionUtils._posOpt;
+var _nnOpt = _optionUtils._nnOpt;
 
 // ── Defaults ────────────────────────────────────────────────────────
 
@@ -74,14 +77,6 @@ function _validateOptions(opts) {
   if (opts.maxPoolSize != null && (typeof opts.maxPoolSize !== "number" || opts.maxPoolSize < 1)) {
     throw new Error("ChallengePoolManager: maxPoolSize must be a positive number");
   }
-}
-
-function _posOpt(val, fallback) {
-  return val != null && val > 0 ? val : fallback;
-}
-
-function _nnOpt(val, fallback) {
-  return val != null && val >= 0 ? val : fallback;
 }
 
 // ── Pool Entry ──────────────────────────────────────────────────────

--- a/src/option-utils.js
+++ b/src/option-utils.js
@@ -1,0 +1,39 @@
+/**
+ * option-utils.js — Shared option-parsing helpers for gif-captcha.
+ *
+ * Consolidates _posOpt and _nnOpt which were previously duplicated in
+ * index.js, challenge-pool-manager.js, and webhook-dispatcher.js.
+ *
+ * @module gif-captcha/option-utils
+ */
+
+"use strict";
+
+/**
+ * Extract a positive-number option, falling back to a default.
+ *
+ * @param {*}      val      The option value to check
+ * @param {number} fallback Default when val is null/undefined/non-positive
+ * @returns {number}
+ */
+function _posOpt(val, fallback) {
+  return val != null && val > 0 ? val : fallback;
+}
+
+/**
+ * Extract a non-negative-number option, falling back to a default.
+ *
+ * @param {*}      val      The option value to check
+ * @param {number} fallback Default when val is null/undefined/negative
+ * @returns {number}
+ */
+function _nnOpt(val, fallback) {
+  return val != null && val >= 0 ? val : fallback;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    _posOpt: _posOpt,
+    _nnOpt: _nnOpt,
+  };
+}

--- a/src/webhook-dispatcher.js
+++ b/src/webhook-dispatcher.js
@@ -16,6 +16,7 @@
  */
 
 const crypto = require("crypto");
+const { _posOpt } = require("./option-utils");
 
 // ── Default Config ──────────────────────────────────────────────────
 
@@ -121,10 +122,6 @@ function WebhookDispatcher(options) {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
-
-function _posOpt(val, fallback) {
-  return val != null && val > 0 ? val : fallback;
-}
 
 function _generateId(counter) {
   return "wh_" + Date.now().toString(36) + "_" + counter;


### PR DESCRIPTION
## What

Extracts the duplicated \_posOpt\ and \_nnOpt\ helper functions into a new shared module \src/option-utils.js\.

## Why

These helpers were copy-pasted in 3 places:
- \src/index.js\ (canonical)
- \src/webhook-dispatcher.js\ (local copy)
- \src/challenge-pool-manager.js\ (local copy)

This creates maintenance risk — a fix in one copy wouldn't propagate to others.

## Changes

- **New:** \src/option-utils.js\ — canonical \_posOpt\ and \_nnOpt\
- **Updated:** \src/webhook-dispatcher.js\ — imports from option-utils instead of local definition
- **Updated:** \src/challenge-pool-manager.js\ — imports from option-utils instead of local definition

All existing tests pass (the 1 failure in challenge-rotation-scheduler is pre-existing and unrelated).