### PR TITLE
feat: Session Replay Viewer dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,6 +217,8 @@
         <p style="margin-top: 0.4rem; font-size: 0.8rem; color: #8b949e;">Schedule automatic CAPTCHA challenge-type rotation across the week with a visual grid, rules engine, and JSON config export</p>
         <a href="solve-histogram.html" style="display: inline-block; margin-top: 0.8rem; padding: 0.6rem 1.5rem; background: #161b22; color: #39d2c0; border: 1px solid #30363d; border-radius: 8px; font-weight: 600; font-size: 0.9rem; text-decoration: none;">📊 Solve Time Histogram →</a>
         <p style="margin-top: 0.4rem; font-size: 0.8rem; color: #8b949e;">Visualize solve-time distributions with interactive histogram, KDE overlay, bot detection threshold, percentile table, and CSV import</p>
+        <a href="session-replay.html" style="display: inline-block; margin-top: 0.8rem; padding: 0.6rem 1.5rem; background: #161b22; color: #bc8cff; border: 1px solid #30363d; border-radius: 8px; font-weight: 600; font-size: 0.9rem; text-decoration: none;">🎬 Session Replay →</a>
+        <p style="margin-top: 0.4rem; font-size: 0.8rem; color: #8b949e;">Replay recorded CAPTCHA-solving sessions with animated mouse trails, click visualization, event timeline, and click heatmap</p>
     </div>
 
     <footer>

--- a/session-replay.html
+++ b/session-replay.html
@@ -1,0 +1,756 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self' 'unsafe-inline'; img-src https: data:; script-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'self'; form-action 'none';">
+    <meta name="referrer" content="no-referrer">
+    <title>GIF CAPTCHA — Session Replay Viewer 🎬</title>
+    <link rel="stylesheet" href="shared.css">
+    <style>
+        .container { max-width: 1100px; }
+
+        /* ── Layout ─────────────────────────────────── */
+        .replay-layout {
+            display: grid;
+            grid-template-columns: 1fr 320px;
+            gap: 1.5rem;
+            margin-bottom: 1.5rem;
+        }
+        @media (max-width: 820px) {
+            .replay-layout { grid-template-columns: 1fr; }
+        }
+
+        /* ── Canvas Stage ───────────────────────────── */
+        .stage-wrap {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 1rem;
+            position: relative;
+        }
+        .stage-canvas {
+            width: 100%;
+            height: 380px;
+            background: #0a0e14;
+            border-radius: 6px;
+            cursor: crosshair;
+        }
+        .stage-overlay {
+            position: absolute;
+            top: 1rem; left: 1rem; right: 1rem;
+            display: flex;
+            justify-content: space-between;
+            pointer-events: none;
+            font-size: 0.8rem;
+            color: var(--muted);
+            padding: 0.4rem 0.6rem;
+        }
+        .stage-overlay .badge {
+            background: rgba(0,0,0,0.6);
+            border-radius: 4px;
+            padding: 0.2rem 0.5rem;
+        }
+
+        /* ── Transport bar ──────────────────────────── */
+        .transport {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            margin-top: 0.75rem;
+            flex-wrap: wrap;
+        }
+        .transport button {
+            background: var(--surface-hover);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text);
+            padding: 0.35rem 0.7rem;
+            cursor: pointer;
+            font-size: 0.85rem;
+        }
+        .transport button:hover { border-color: var(--accent); }
+        .transport button.active { background: var(--accent); color: #000; }
+        .transport .scrubber {
+            flex: 1;
+            accent-color: var(--accent);
+            min-width: 120px;
+        }
+        .transport .time-label {
+            font-size: 0.8rem;
+            color: var(--muted);
+            min-width: 80px;
+            text-align: right;
+        }
+        .speed-select {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text);
+            padding: 0.3rem 0.5rem;
+            font-size: 0.8rem;
+        }
+
+        /* ── Sidebar ────────────────────────────────── */
+        .sidebar { display: flex; flex-direction: column; gap: 1rem; }
+
+        .session-picker {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 1rem;
+        }
+        .session-picker h3 {
+            font-size: 0.9rem;
+            margin-bottom: 0.5rem;
+            color: var(--accent);
+        }
+        .session-list {
+            max-height: 160px;
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+            gap: 0.3rem;
+        }
+        .session-item {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 0.45rem 0.6rem;
+            cursor: pointer;
+            font-size: 0.8rem;
+            display: flex;
+            justify-content: space-between;
+            transition: border-color 0.15s;
+        }
+        .session-item:hover { border-color: var(--accent); }
+        .session-item.selected { border-color: var(--accent); background: rgba(88,166,255,0.08); }
+        .session-item .tag {
+            font-size: 0.7rem;
+            border-radius: 3px;
+            padding: 0.1rem 0.35rem;
+        }
+        .tag-solved { background: var(--green-bg); color: var(--green); }
+        .tag-failed { background: var(--red-bg); color: var(--red); }
+
+        /* ── Event log ──────────────────────────────── */
+        .event-log {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 1rem;
+            flex: 1;
+            min-height: 0;
+        }
+        .event-log h3 {
+            font-size: 0.9rem;
+            margin-bottom: 0.5rem;
+            color: var(--accent);
+        }
+        .event-list {
+            max-height: 260px;
+            overflow-y: auto;
+            font-family: 'SFMono-Regular', Consolas, monospace;
+            font-size: 0.75rem;
+            line-height: 1.6;
+        }
+        .event-row {
+            display: flex;
+            gap: 0.5rem;
+            padding: 0.15rem 0.3rem;
+            border-radius: 3px;
+            transition: background 0.1s;
+        }
+        .event-row.highlight { background: rgba(88,166,255,0.12); }
+        .event-row .ts { color: var(--muted); min-width: 50px; }
+        .event-row .etype { min-width: 90px; }
+        .etype-mouse_move { color: var(--cyan); }
+        .etype-click { color: var(--green); }
+        .etype-solve_attempt { color: var(--yellow); }
+        .etype-key_press { color: var(--purple); }
+        .etype-focus, .etype-blur { color: var(--orange); }
+
+        /* ── Stats strip ────────────────────────────── */
+        .stats-strip {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+        }
+        .mini-stat {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 0.75rem;
+            text-align: center;
+        }
+        .mini-stat .val { font-size: 1.4rem; font-weight: 700; }
+        .mini-stat .lbl { font-size: 0.75rem; color: var(--muted); margin-top: 0.2rem; }
+
+        /* ── Heatmap ────────────────────────────────── */
+        .heatmap-section {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 1rem;
+            margin-bottom: 1.5rem;
+        }
+        .heatmap-section h3 {
+            font-size: 0.95rem;
+            margin-bottom: 0.75rem;
+            color: var(--accent);
+        }
+        .heatmap-canvas {
+            width: 100%;
+            height: 260px;
+            background: #0a0e14;
+            border-radius: 6px;
+        }
+
+        /* ── Import area ────────────────────────────── */
+        .import-area {
+            background: var(--surface);
+            border: 2px dashed var(--border);
+            border-radius: 10px;
+            padding: 2rem;
+            text-align: center;
+            color: var(--muted);
+            cursor: pointer;
+            transition: border-color 0.2s;
+            margin-bottom: 1.5rem;
+        }
+        .import-area:hover { border-color: var(--accent); }
+        .import-area input[type="file"] { display: none; }
+
+        .generate-btn {
+            display: inline-block;
+            margin-top: 0.75rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🎬 Session Replay Viewer</h1>
+            <p>Visualize and replay recorded CAPTCHA-solving sessions — mouse paths, clicks, solve attempts, and behavioral patterns.</p>
+            <nav class="nav-links">
+                <a href="index.html">Home</a>
+                <a href="dashboard.html">Dashboard</a>
+                <a href="analysis.html">Analysis</a>
+                <a href="heatmap.html">Heatmap</a>
+                <a href="solve-histogram.html">Histogram</a>
+            </nav>
+        </div>
+
+        <!-- Import / Demo data -->
+        <div class="import-area" id="importArea">
+            <p>📂 Drop a session-replay JSON export here, or click to browse</p>
+            <p style="font-size:0.8rem; margin-top:0.4rem;">
+                Exported via <code>replay.exportJSON()</code> from captcha-session-replay module
+            </p>
+            <button class="btn generate-btn" id="btnDemo">Generate Demo Data</button>
+            <input type="file" id="fileInput" accept=".json,application/json">
+        </div>
+
+        <!-- Stats strip -->
+        <div class="stats-strip" id="statsStrip" style="display:none;">
+            <div class="mini-stat"><div class="val" id="statTotal">0</div><div class="lbl">Sessions</div></div>
+            <div class="mini-stat"><div class="val" id="statSolved">0</div><div class="lbl">Solved</div></div>
+            <div class="mini-stat"><div class="val" id="statAvgTime">—</div><div class="lbl">Avg Solve (s)</div></div>
+            <div class="mini-stat"><div class="val" id="statEvents">0</div><div class="lbl">Total Events</div></div>
+            <div class="mini-stat"><div class="val" id="statAvgClicks">—</div><div class="lbl">Avg Clicks</div></div>
+        </div>
+
+        <!-- Main replay area -->
+        <div class="replay-layout" id="replayArea" style="display:none;">
+            <div>
+                <div class="stage-wrap">
+                    <canvas class="stage-canvas" id="stageCanvas"></canvas>
+                    <div class="stage-overlay">
+                        <span class="badge" id="badgeType">—</span>
+                        <span class="badge" id="badgeTime">0.0s</span>
+                    </div>
+                </div>
+                <div class="transport">
+                    <button id="btnPlay" title="Play / Pause">▶</button>
+                    <button id="btnStop" title="Stop">⏹</button>
+                    <input type="range" class="scrubber" id="scrubber" min="0" max="1000" value="0">
+                    <select class="speed-select" id="speedSelect">
+                        <option value="0.25">0.25×</option>
+                        <option value="0.5">0.5×</option>
+                        <option value="1" selected>1×</option>
+                        <option value="2">2×</option>
+                        <option value="4">4×</option>
+                        <option value="8">8×</option>
+                    </select>
+                    <span class="time-label" id="timeLabel">0.0s / 0.0s</span>
+                </div>
+            </div>
+
+            <div class="sidebar">
+                <div class="session-picker">
+                    <h3>📋 Sessions</h3>
+                    <div class="session-list" id="sessionList"></div>
+                </div>
+                <div class="event-log">
+                    <h3>📝 Events</h3>
+                    <div class="event-list" id="eventList"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Click heatmap -->
+        <div class="heatmap-section" id="heatmapSection" style="display:none;">
+            <h3>🔥 Click Heatmap (all sessions)</h3>
+            <canvas class="heatmap-canvas" id="heatmapCanvas"></canvas>
+        </div>
+
+        <footer class="footer">
+            gif-captcha &middot; Session Replay Viewer &middot; Research Use
+        </footer>
+    </div>
+
+    <script src="shared.js"></script>
+    <script>
+    (function () {
+        "use strict";
+
+        /* ── State ──────────────────────────────── */
+        var sessions = [];
+        var activeIdx = -1;
+        var playing = false;
+        var playStart = 0;     // Date.now() when play started
+        var playOffset = 0;    // ms offset when paused
+        var speed = 1;
+        var rafId = null;
+
+        /* ── DOM refs ───────────────────────────── */
+        var importArea  = document.getElementById("importArea");
+        var fileInput   = document.getElementById("fileInput");
+        var btnDemo     = document.getElementById("btnDemo");
+        var statsStrip  = document.getElementById("statsStrip");
+        var replayArea  = document.getElementById("replayArea");
+        var heatmapSec  = document.getElementById("heatmapSection");
+        var sessionList = document.getElementById("sessionList");
+        var eventList   = document.getElementById("eventList");
+        var stageCanvas = document.getElementById("stageCanvas");
+        var heatmapCanvas = document.getElementById("heatmapCanvas");
+        var btnPlay     = document.getElementById("btnPlay");
+        var btnStop     = document.getElementById("btnStop");
+        var scrubber    = document.getElementById("scrubber");
+        var speedSelect = document.getElementById("speedSelect");
+        var timeLabel   = document.getElementById("timeLabel");
+        var badgeType   = document.getElementById("badgeType");
+        var badgeTime   = document.getElementById("badgeTime");
+
+        /* ── Canvas setup ───────────────────────── */
+        function sizeCanvas(cv) {
+            var r = cv.getBoundingClientRect();
+            cv.width = r.width * devicePixelRatio;
+            cv.height = r.height * devicePixelRatio;
+        }
+
+        /* ── Import / Demo ──────────────────────── */
+        importArea.addEventListener("click", function (e) {
+            if (e.target === btnDemo || e.target.closest(".generate-btn")) return;
+            fileInput.click();
+        });
+        importArea.addEventListener("dragover", function (e) { e.preventDefault(); });
+        importArea.addEventListener("drop", function (e) {
+            e.preventDefault();
+            var f = e.dataTransfer.files[0];
+            if (f) readFile(f);
+        });
+        fileInput.addEventListener("change", function () {
+            if (fileInput.files[0]) readFile(fileInput.files[0]);
+        });
+
+        function readFile(f) {
+            var reader = new FileReader();
+            reader.onload = function () {
+                try {
+                    var data = JSON.parse(reader.result);
+                    loadSessions(Array.isArray(data) ? data : data.sessions || [data]);
+                } catch (err) {
+                    alert("Invalid JSON: " + err.message);
+                }
+            };
+            reader.readAsText(f);
+        }
+
+        btnDemo.addEventListener("click", function (e) {
+            e.stopPropagation();
+            loadSessions(generateDemo());
+        });
+
+        /* ── Demo data generator ────────────────── */
+        function generateDemo() {
+            var types = ["sequence", "direction", "color", "object"];
+            var out = [];
+            for (var s = 0; s < 8; s++) {
+                var events = [];
+                var t = 0;
+                var cx = 200 + Math.random() * 200;
+                var cy = 100 + Math.random() * 200;
+                // mouse path
+                for (var m = 0; m < 30 + Math.floor(Math.random() * 40); m++) {
+                    cx += (Math.random() - 0.5) * 40;
+                    cy += (Math.random() - 0.5) * 30;
+                    cx = Math.max(10, Math.min(590, cx));
+                    cy = Math.max(10, Math.min(370, cy));
+                    t += 30 + Math.random() * 80;
+                    events.push({ type: "mouse_move", ts: Math.round(t), data: { x: Math.round(cx), y: Math.round(cy) } });
+                }
+                // clicks
+                var clicks = 2 + Math.floor(Math.random() * 5);
+                for (var c = 0; c < clicks; c++) {
+                    t += 200 + Math.random() * 600;
+                    var ex = 50 + Math.random() * 500;
+                    var ey = 30 + Math.random() * 340;
+                    events.push({ type: "click", ts: Math.round(t), data: { x: Math.round(ex), y: Math.round(ey), target: "frame-" + (c + 1) } });
+                }
+                // solve attempt
+                var solved = Math.random() > 0.3;
+                t += 300 + Math.random() * 500;
+                events.push({ type: "solve_attempt", ts: Math.round(t), data: { correct: solved } });
+
+                events.sort(function (a, b) { return a.ts - b.ts; });
+                out.push({
+                    id: "demo-" + (s + 1),
+                    challengeType: types[s % types.length],
+                    solved: solved,
+                    duration: Math.round(t),
+                    events: events
+                });
+            }
+            return out;
+        }
+
+        /* ── Load sessions ──────────────────────── */
+        function loadSessions(data) {
+            sessions = data;
+            importArea.style.display = "none";
+            statsStrip.style.display = "";
+            replayArea.style.display = "";
+            heatmapSec.style.display = "";
+
+            // Stats
+            var totalEv = 0, solvedCt = 0, totalTime = 0, totalClicks = 0;
+            sessions.forEach(function (s) {
+                totalEv += (s.events || []).length;
+                if (s.solved) solvedCt++;
+                totalTime += (s.duration || 0);
+                totalClicks += (s.events || []).filter(function (e) { return e.type === "click"; }).length;
+            });
+            document.getElementById("statTotal").textContent = sessions.length;
+            document.getElementById("statSolved").textContent = solvedCt;
+            document.getElementById("statAvgTime").textContent = sessions.length ? (totalTime / sessions.length / 1000).toFixed(1) : "—";
+            document.getElementById("statEvents").textContent = totalEv;
+            document.getElementById("statAvgClicks").textContent = sessions.length ? (totalClicks / sessions.length).toFixed(1) : "—";
+
+            // Session list
+            sessionList.innerHTML = "";
+            sessions.forEach(function (s, i) {
+                var div = document.createElement("div");
+                div.className = "session-item" + (i === 0 ? " selected" : "");
+                div.innerHTML = '<span>' + sanitize(s.id || "Session " + (i + 1)) + '</span>' +
+                    '<span class="tag ' + (s.solved ? "tag-solved" : "tag-failed") + '">' + (s.solved ? "✓" : "✗") + "</span>";
+                div.addEventListener("click", function () { selectSession(i); });
+                sessionList.appendChild(div);
+            });
+
+            selectSession(0);
+            drawHeatmap();
+        }
+
+        /* ── Select session ─────────────────────── */
+        function selectSession(idx) {
+            stopPlayback();
+            activeIdx = idx;
+            var items = sessionList.querySelectorAll(".session-item");
+            for (var i = 0; i < items.length; i++) items[i].classList.toggle("selected", i === idx);
+
+            var s = sessions[idx];
+            badgeType.textContent = s.challengeType || "unknown";
+
+            // Build event list
+            eventList.innerHTML = "";
+            (s.events || []).forEach(function (ev, ei) {
+                var row = document.createElement("div");
+                row.className = "event-row";
+                row.dataset.idx = ei;
+                var secs = (ev.ts / 1000).toFixed(2);
+                var detail = "";
+                if (ev.data) {
+                    if (ev.data.x !== undefined) detail = "(" + ev.data.x + "," + ev.data.y + ")";
+                    if (ev.data.correct !== undefined) detail = ev.data.correct ? "✓ correct" : "✗ wrong";
+                    if (ev.data.target) detail += " " + ev.data.target;
+                }
+                row.innerHTML = '<span class="ts">' + secs + 's</span>' +
+                    '<span class="etype etype-' + sanitize(ev.type) + '">' + sanitize(ev.type) + '</span>' +
+                    '<span>' + sanitize(detail) + '</span>';
+                eventList.appendChild(row);
+            });
+
+            // Reset transport
+            playOffset = 0;
+            scrubber.value = 0;
+            updateTimeLabel(0);
+            drawFrame(0);
+        }
+
+        /* ── Playback ───────────────────────────── */
+        speedSelect.addEventListener("change", function () { speed = parseFloat(speedSelect.value); });
+
+        btnPlay.addEventListener("click", function () {
+            if (activeIdx < 0) return;
+            if (playing) { pausePlayback(); } else { startPlayback(); }
+        });
+        btnStop.addEventListener("click", function () { stopPlayback(); drawFrame(0); });
+
+        scrubber.addEventListener("input", function () {
+            if (activeIdx < 0) return;
+            var s = sessions[activeIdx];
+            var dur = s.duration || 1;
+            var ms = (scrubber.value / 1000) * dur;
+            playOffset = ms;
+            if (playing) { playStart = Date.now(); }
+            drawFrame(ms);
+            updateTimeLabel(ms);
+        });
+
+        function startPlayback() {
+            playing = true;
+            btnPlay.textContent = "⏸";
+            playStart = Date.now();
+            tick();
+        }
+        function pausePlayback() {
+            playing = false;
+            btnPlay.textContent = "▶";
+            cancelAnimationFrame(rafId);
+            // Store current offset
+            playOffset = playOffset + (Date.now() - playStart) * speed;
+        }
+        function stopPlayback() {
+            playing = false;
+            btnPlay.textContent = "▶";
+            cancelAnimationFrame(rafId);
+            playOffset = 0;
+            scrubber.value = 0;
+            updateTimeLabel(0);
+        }
+
+        function tick() {
+            if (!playing || activeIdx < 0) return;
+            var s = sessions[activeIdx];
+            var dur = s.duration || 1;
+            var elapsed = playOffset + (Date.now() - playStart) * speed;
+            if (elapsed >= dur) {
+                elapsed = dur;
+                playing = false;
+                btnPlay.textContent = "▶";
+            }
+            scrubber.value = Math.round((elapsed / dur) * 1000);
+            drawFrame(elapsed);
+            updateTimeLabel(elapsed);
+            highlightEvent(elapsed);
+            if (playing) rafId = requestAnimationFrame(tick);
+        }
+
+        function updateTimeLabel(ms) {
+            var dur = (activeIdx >= 0 ? sessions[activeIdx].duration : 0) || 0;
+            timeLabel.textContent = (ms / 1000).toFixed(1) + "s / " + (dur / 1000).toFixed(1) + "s";
+            badgeTime.textContent = (ms / 1000).toFixed(1) + "s";
+        }
+
+        function highlightEvent(ms) {
+            var rows = eventList.querySelectorAll(".event-row");
+            var lastMatch = -1;
+            var evts = sessions[activeIdx].events || [];
+            for (var i = 0; i < evts.length; i++) {
+                if (evts[i].ts <= ms) lastMatch = i;
+                else break;
+            }
+            for (var j = 0; j < rows.length; j++) {
+                rows[j].classList.toggle("highlight", j === lastMatch);
+            }
+            if (lastMatch >= 0 && rows[lastMatch]) {
+                rows[lastMatch].scrollIntoView({ block: "nearest" });
+            }
+        }
+
+        /* ── Canvas drawing ─────────────────────── */
+        function drawFrame(ms) {
+            sizeCanvas(stageCanvas);
+            var ctx = stageCanvas.getContext("2d");
+            var w = stageCanvas.width, h = stageCanvas.height;
+            var sx = w / 600, sy = h / 380; // normalize to 600×380 virtual space
+
+            ctx.clearRect(0, 0, w, h);
+
+            if (activeIdx < 0) return;
+            var evts = sessions[activeIdx].events || [];
+
+            // Collect visible events
+            var trail = [];
+            var clicks = [];
+            var cursor = null;
+
+            for (var i = 0; i < evts.length; i++) {
+                var ev = evts[i];
+                if (ev.ts > ms) break;
+                if (ev.type === "mouse_move" && ev.data) {
+                    trail.push({ x: ev.data.x * sx, y: ev.data.y * sy, ts: ev.ts });
+                    cursor = { x: ev.data.x * sx, y: ev.data.y * sy };
+                }
+                if (ev.type === "click" && ev.data) {
+                    clicks.push({ x: ev.data.x * sx, y: ev.data.y * sy, ts: ev.ts, target: ev.data.target });
+                    cursor = { x: ev.data.x * sx, y: ev.data.y * sy };
+                }
+            }
+
+            // Draw trail
+            if (trail.length > 1) {
+                ctx.beginPath();
+                ctx.moveTo(trail[0].x, trail[0].y);
+                for (var t = 1; t < trail.length; t++) {
+                    ctx.lineTo(trail[t].x, trail[t].y);
+                }
+                ctx.strokeStyle = "rgba(57,210,192,0.4)";
+                ctx.lineWidth = 2 * devicePixelRatio;
+                ctx.lineJoin = "round";
+                ctx.stroke();
+
+                // Fade older segments
+                for (var t2 = 0; t2 < trail.length; t2++) {
+                    var age = (ms - trail[t2].ts) / (ms || 1);
+                    var alpha = Math.max(0.05, 1 - age * 0.8);
+                    ctx.beginPath();
+                    ctx.arc(trail[t2].x, trail[t2].y, 2 * devicePixelRatio, 0, Math.PI * 2);
+                    ctx.fillStyle = "rgba(57,210,192," + alpha.toFixed(2) + ")";
+                    ctx.fill();
+                }
+            }
+
+            // Draw clicks
+            clicks.forEach(function (cl) {
+                var age = (ms - cl.ts) / 500;
+                var r = (8 + Math.min(age, 1) * 16) * devicePixelRatio;
+                var alpha = Math.max(0, 1 - age * 0.5);
+
+                ctx.beginPath();
+                ctx.arc(cl.x, cl.y, r, 0, Math.PI * 2);
+                ctx.strokeStyle = "rgba(63,185,80," + alpha.toFixed(2) + ")";
+                ctx.lineWidth = 2 * devicePixelRatio;
+                ctx.stroke();
+
+                ctx.beginPath();
+                ctx.arc(cl.x, cl.y, 4 * devicePixelRatio, 0, Math.PI * 2);
+                ctx.fillStyle = "rgba(63,185,80,0.8)";
+                ctx.fill();
+
+                if (cl.target) {
+                    ctx.font = (10 * devicePixelRatio) + "px sans-serif";
+                    ctx.fillStyle = "rgba(255,255,255,0.7)";
+                    ctx.fillText(cl.target, cl.x + 8 * devicePixelRatio, cl.y - 8 * devicePixelRatio);
+                }
+            });
+
+            // Draw cursor
+            if (cursor) {
+                ctx.beginPath();
+                ctx.arc(cursor.x, cursor.y, 6 * devicePixelRatio, 0, Math.PI * 2);
+                ctx.fillStyle = "rgba(88,166,255,0.9)";
+                ctx.fill();
+                ctx.beginPath();
+                ctx.arc(cursor.x, cursor.y, 10 * devicePixelRatio, 0, Math.PI * 2);
+                ctx.strokeStyle = "rgba(88,166,255,0.4)";
+                ctx.lineWidth = 2 * devicePixelRatio;
+                ctx.stroke();
+            }
+        }
+
+        /* ── Heatmap ────────────────────────────── */
+        function drawHeatmap() {
+            sizeCanvas(heatmapCanvas);
+            var ctx = heatmapCanvas.getContext("2d");
+            var w = heatmapCanvas.width, h = heatmapCanvas.height;
+            var sx = w / 600, sy = h / 380;
+
+            ctx.clearRect(0, 0, w, h);
+
+            // Collect all clicks
+            var allClicks = [];
+            sessions.forEach(function (s) {
+                (s.events || []).forEach(function (ev) {
+                    if (ev.type === "click" && ev.data && ev.data.x !== undefined) {
+                        allClicks.push({ x: ev.data.x * sx, y: ev.data.y * sy });
+                    }
+                });
+            });
+
+            if (!allClicks.length) {
+                ctx.fillStyle = "rgba(139,148,158,0.5)";
+                ctx.font = (14 * devicePixelRatio) + "px sans-serif";
+                ctx.textAlign = "center";
+                ctx.fillText("No click data", w / 2, h / 2);
+                return;
+            }
+
+            // Simple grid-based heatmap
+            var cellW = 20 * devicePixelRatio;
+            var cols = Math.ceil(w / cellW), rows = Math.ceil(h / cellW);
+            var grid = new Float32Array(cols * rows);
+            var maxVal = 0;
+
+            allClicks.forEach(function (c) {
+                var col = Math.min(cols - 1, Math.max(0, Math.floor(c.x / cellW)));
+                var row = Math.min(rows - 1, Math.max(0, Math.floor(c.y / cellW)));
+                // Spread to neighbors
+                for (var dy = -1; dy <= 1; dy++) {
+                    for (var dx = -1; dx <= 1; dx++) {
+                        var nc = col + dx, nr = row + dy;
+                        if (nc >= 0 && nc < cols && nr >= 0 && nr < rows) {
+                            var dist = Math.sqrt(dx * dx + dy * dy);
+                            var w2 = dist === 0 ? 1 : 0.4;
+                            grid[nr * cols + nc] += w2;
+                        }
+                    }
+                }
+            });
+            for (var i = 0; i < grid.length; i++) if (grid[i] > maxVal) maxVal = grid[i];
+
+            // Render
+            for (var r = 0; r < rows; r++) {
+                for (var c2 = 0; c2 < cols; c2++) {
+                    var val = grid[r * cols + c2];
+                    if (val === 0) continue;
+                    var norm = val / maxVal;
+                    var red = Math.round(255 * Math.min(1, norm * 2));
+                    var green = norm < 0.5 ? Math.round(255 * norm * 2) : Math.round(255 * (1 - (norm - 0.5) * 2));
+                    var blue = Math.round(255 * Math.max(0, 1 - norm * 2));
+                    ctx.fillStyle = "rgba(" + red + "," + green + "," + blue + "," + (0.3 + norm * 0.5).toFixed(2) + ")";
+                    ctx.fillRect(c2 * cellW, r * cellW, cellW, cellW);
+                }
+            }
+
+            // Overlay click dots
+            ctx.fillStyle = "rgba(255,255,255,0.3)";
+            allClicks.forEach(function (c) {
+                ctx.beginPath();
+                ctx.arc(c.x, c.y, 2 * devicePixelRatio, 0, Math.PI * 2);
+                ctx.fill();
+            });
+        }
+
+        /* ── Resize handler ─────────────────────── */
+        window.addEventListener("resize", function () {
+            if (activeIdx >= 0) drawFrame(playOffset);
+            if (sessions.length) drawHeatmap();
+        });
+
+    })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Interactive HTML dashboard for visualizing captcha-session-replay data:

- **Canvas playback** — animated mouse trails, click ripples, cursor tracking
- **Transport controls** — play/pause/stop, scrubber, variable speed (0.25×–8×)
- **Session picker** — sidebar with solved/failed tags, click to switch
- **Event log** — scrolling, type-colored event list with auto-highlight during playback
- **Stats strip** — total sessions, solve rate, avg solve time, total events, avg clicks
- **Click heatmap** — aggregate heatmap across all loaded sessions
- **Import** — drag-and-drop or browse for JSON exports from \captcha-session-replay\ module
- **Demo data** — one-click demo generation for quick testing
- Uses shared.css/shared.js design system